### PR TITLE
Skip row instead of continue processing (in debug mode) when product …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# Version 1.0.0-beta39
+
+## Bugfixes
+
+* Skip row instead of continue processing (in debug mode) when product with SKU can not be loaded in LastEntityIdObserver
+
+## Features
+
+* None
+
 # Version 1.0.0-beta38
 
 ## Bugfixes

--- a/src/Observers/LastEntityIdObserver.php
+++ b/src/Observers/LastEntityIdObserver.php
@@ -87,7 +87,10 @@ class LastEntityIdObserver extends AbstractProductImportObserver
             $subject = $this->getSubject();
             // query whether or not debug mode has been enabled
             if ($subject->isDebugMode()) {
+                // log a warning, that the product with the given SKU can not be loaded
                 $subject->getSystemLogger()->warning($subject->appendExceptionSuffix($message));
+                // skip processing the actual row
+                $subject->skipRow();
             } else {
                 throw new \Exception($message);
             }


### PR DESCRIPTION
…with SKU can not be loaded in LastEntityIdObserver