### PR TITLE
Fix product update return ID

### DIFF
--- a/src/Actions/Processors/ProductUpdateProcessor.php
+++ b/src/Actions/Processors/ProductUpdateProcessor.php
@@ -63,6 +63,6 @@ class ProductUpdateProcessor extends AbstractUpdateProcessor
     public function execute($row, $name = null, $primaryKeyMemberName = null)
     {
         parent::execute($row, $name);
-        return $row[MemberNames::ENTITY_ID];
+        return $row[$primaryKeyMemberName ?: MemberNames::ENTITY_ID];
     }
 }


### PR DESCRIPTION
When used in EE context it passes in `row_id` as `$primaryKeyMemberName`

It is an attempt to fix https://github.com/techdivision/import-ee/issues/20

(PS: There may be more proper way to fix it)
