### PR TITLE
PAC-252 - Add new config key for generating category product rewrites

### DIFF
--- a/src/Utils/CoreConfigDataKeys.php
+++ b/src/Utils/CoreConfigDataKeys.php
@@ -45,4 +45,11 @@ class CoreConfigDataKeys extends \TechDivision\Import\Utils\CoreConfigDataKeys
      * @var string
      */
     const CATALOG_SEO_SAVE_REWRITES_HISTORY = 'catalog/seo/save_rewrites_history';
+
+    /**
+     * Name for the column 'catalog/seo/generate_category_product_rewrites'.
+     *
+     * @var string
+     */
+    const CATALOG_SEO_GENERATE_CATEGORY_PRODUCT_REWRITES = 'catalog/seo/generate_category_product_rewrites';
 }


### PR DESCRIPTION
Adds a new configuration key for querying whether or not generating category product rewrites is enabled.