### PR TITLE
Add cleanup functionality on product link to remove product relations

### DIFF
--- a/etc/configuration/operations.json
+++ b/etc/configuration/operations.json
@@ -601,6 +601,7 @@
                     "media-directory" : "pub/media/catalog/product",
                     "images-file-directory" : "var/importexport/media/catalog/product",
                     "clean-up-variants": false,
+                    "clean-up-links": false,
                     "clean-up-media-gallery": true,
                     "clean-up-empty-image-columns": true,
                     "clean-up-website-product-relations": true,

--- a/src/Subjects/AbstractProductSubject.php
+++ b/src/Subjects/AbstractProductSubject.php
@@ -178,6 +178,13 @@ abstract class AbstractProductSubject extends AbstractEavSubject implements Enti
     );
 
     /**
+     * The array with the columns that has to be cleaned-up.
+     *
+     * @var array
+     */
+    protected $cleanUpColumns = array();
+
+    /**
      * Return's the default callback frontend input mappings for the user defined attributes.
      *
      * @return array The default frontend input callback mappings
@@ -315,6 +322,9 @@ abstract class AbstractProductSubject extends AbstractEavSubject implements Enti
 
         // prepare the link type mappings
         $this->linkTypeMappings = $this->prepareLinkTypeMappings();
+
+        // prepare the columns that has to be cleaned-up
+        $this->cleanUpColumns = $this->prepareCleanUpColumns();
 
         // invoke the parent method
         parent::setUp($serial);
@@ -628,41 +638,7 @@ abstract class AbstractProductSubject extends AbstractEavSubject implements Enti
      */
     public function getCleanUpColumns()
     {
-
-        // load the colums that has to be cleaned-up
-        $cleanUpColumns = $this->getConfiguration()->getParam(ConfigurationKeys::CLEAN_UP_EMPTY_COLUMNS);
-
-        // query whether or not the image columns has to be cleaned-up also
-        if ($this->getConfiguration()->hasParam(ConfigurationKeys::CLEAN_UP_EMPTY_IMAGE_COLUMNS) &&
-            $this->getConfiguration()->getParam(ConfigurationKeys::CLEAN_UP_EMPTY_IMAGE_COLUMNS, false)
-        ) {
-            // if yes load the image column names
-            $imageTypes = array_keys($this->getImageTypes());
-
-            // and append them to the column names from the configuration
-            foreach ($imageTypes as $imageAttribute) {
-                $cleanUpColumns[] = $this->mapAttributeCodeByHeaderMapping($imageAttribute);
-            }
-        }
-
-        // query whether or not the columns with the product links has to be cleaned-up also
-        if ($this->getConfiguration()->hasParam(ConfigurationKeys::CLEAN_UP_LINKS) &&
-            $this->getConfiguration()->getParam(ConfigurationKeys::CLEAN_UP_LINKS, false)
-        ) {
-            // load the link type mappings
-            $linkTypeMappings = $this->getLinkTypeMappings();
-
-            // prepare the links for the found link types and clean up
-            foreach ($linkTypeMappings as $columns) {
-                // shift the column with the header information from the stack
-                list ($columnNameChildSkus, ) = array_shift($columns);
-                // append the column name from the link type mapping
-                $cleanUpColumns[] = $columnNameChildSkus;
-            }
-        }
-
-        // return the array with the column names that has to be cleaned-up
-        return $cleanUpColumns;
+        return $this->cleanUpColumns;
     }
 
     /**
@@ -894,6 +870,58 @@ abstract class AbstractProductSubject extends AbstractEavSubject implements Enti
 
         // return the link type mappings
         return $linkTypeMappings;
+    }
+
+    /**
+     * Return's the columns that has to be cleaned-up.
+     *
+     * @return array The mapping with the columns that has to be cleaned-up
+     */
+    public function prepareCleanUpColumns()
+    {
+
+        // initialize the array with the colums that has to be cleaned-up
+        $cleanUpColumns = array();
+
+        // try to load the colums that has to be cleaned-up
+        if ($this->getConfiguration()->hasParam(ConfigurationKeys::CLEAN_UP_EMPTY_COLUMNS)) {
+            $cleanUpColumns = array_merge(
+                $cleanUpColumns,
+                $this->getConfiguration()->getParam(ConfigurationKeys::CLEAN_UP_EMPTY_COLUMNS, array())
+            );
+        }
+
+        // query whether or not the image columns has to be cleaned-up also
+        if ($this->getConfiguration()->hasParam(ConfigurationKeys::CLEAN_UP_EMPTY_IMAGE_COLUMNS) &&
+            $this->getConfiguration()->getParam(ConfigurationKeys::CLEAN_UP_EMPTY_IMAGE_COLUMNS, false)
+        ) {
+            // if yes load the image column names
+            $imageTypes = array_keys($this->getImageTypes());
+
+            // and append them to the column names from the configuration
+            foreach ($imageTypes as $imageAttribute) {
+                $cleanUpColumns[] = $this->mapAttributeCodeByHeaderMapping($imageAttribute);
+            }
+        }
+
+        // query whether or not the columns with the product links has to be cleaned-up also
+        if ($this->getConfiguration()->hasParam(ConfigurationKeys::CLEAN_UP_LINKS) &&
+            $this->getConfiguration()->getParam(ConfigurationKeys::CLEAN_UP_LINKS, false)
+        ) {
+            // load the link type mappings
+            $linkTypeMappings = $this->getLinkTypeMappings();
+
+            // prepare the links for the found link types and clean up
+            foreach ($linkTypeMappings as $columns) {
+                // shift the column with the header information from the stack
+                list ($columnNameChildSkus, ) = array_shift($columns);
+                // append the column name from the link type mapping
+                $cleanUpColumns[] = $columnNameChildSkus;
+            }
+        }
+
+        // return the array with the column names that has to be cleaned-up
+        return $cleanUpColumns;
     }
 
     /**

--- a/src/Subjects/AbstractProductSubject.php
+++ b/src/Subjects/AbstractProductSubject.php
@@ -634,7 +634,7 @@ abstract class AbstractProductSubject extends AbstractEavSubject implements Enti
 
         // query whether or not the image columns has to be cleaned-up also
         if ($this->getConfiguration()->hasParam(ConfigurationKeys::CLEAN_UP_EMPTY_IMAGE_COLUMNS) &&
-            $this->getConfiguration()->hasParam(ConfigurationKeys::CLEAN_UP_EMPTY_IMAGE_COLUMNS, false)
+            $this->getConfiguration()->getParam(ConfigurationKeys::CLEAN_UP_EMPTY_IMAGE_COLUMNS, false)
         ) {
             // if yes load the image column names
             $imageTypes = array_keys($this->getImageTypes());
@@ -642,6 +642,22 @@ abstract class AbstractProductSubject extends AbstractEavSubject implements Enti
             // and append them to the column names from the configuration
             foreach ($imageTypes as $imageAttribute) {
                 $cleanUpColumns[] = $this->mapAttributeCodeByHeaderMapping($imageAttribute);
+            }
+        }
+
+        // query whether or not the columns with the product links has to be cleaned-up also
+        if ($this->getConfiguration()->hasParam(ConfigurationKeys::CLEAN_UP_LINKS) &&
+            $this->getConfiguration()->getParam(ConfigurationKeys::CLEAN_UP_LINKS, false)
+        ) {
+            // load the link type mappings
+            $linkTypeMappings = $this->getLinkTypeMappings();
+
+            // prepare the links for the found link types and clean up
+            foreach ($linkTypeMappings as $columns) {
+                // shift the column with the header information from the stack
+                list ($columnNameChildSkus, ) = array_shift($columns);
+                // append the column name from the link type mapping
+                $cleanUpColumns[] = $columnNameChildSkus;
             }
         }
 

--- a/src/Subjects/BunchSubject.php
+++ b/src/Subjects/BunchSubject.php
@@ -350,27 +350,6 @@ class BunchSubject extends AbstractProductSubject implements ExportableSubjectIn
     }
 
     /**
-     * Merge the columns from the configuration with all image type columns to define which
-     * columns should be cleaned-up.
-     *
-     * @return array The columns that has to be cleaned-up
-     */
-    public function getCleanUpColumns()
-    {
-
-        // initialize the array for the columns that has to be cleaned-up
-        $cleanUpColumns = array();
-
-        // query whether or not an array has been specified in the configuration
-        if ($this->getConfiguration()->hasParam(ConfigurationKeys::CLEAN_UP_EMPTY_COLUMNS)) {
-            $cleanUpColumns = $this->getConfiguration()->getParam(ConfigurationKeys::CLEAN_UP_EMPTY_COLUMNS);
-        }
-
-        // return the array with the column names
-        return $cleanUpColumns;
-    }
-
-    /**
      * Return's the entity type code to be used.
      *
      * @return string The entity type code to be used

--- a/src/Utils/ConfigurationKeys.php
+++ b/src/Utils/ConfigurationKeys.php
@@ -75,6 +75,13 @@ class ConfigurationKeys extends \TechDivision\Import\Utils\ConfigurationKeys
     const CLEAN_UP_EMPTY_IMAGE_COLUMNS = 'clean-up-empty-image-columns';
 
     /**
+     * Name for the configuration key 'clean-up-variants'.
+     *
+     * @var string
+     */
+    const CLEAN_UP_LINKS = 'clean-up-links';
+
+    /**
      * Name for the column 'override-images'.
      *
      * @var string

--- a/symfony/Resources/config/2.3.2/services.xml
+++ b/symfony/Resources/config/2.3.2/services.xml
@@ -166,6 +166,9 @@
                 <argument id="import_product_link.observer.product.link" type="service"/>
             </call>
             <call method="addObserver">
+                <argument id="import_product_link.observer.clean.up.product.link" type="service"/>
+            </call>
+            <call method="addObserver">
                 <argument id="import_product_grouped.observer.product.grouped" type="service"/>
             </call>
             <call method="addObserver">

--- a/symfony/Resources/config/services.xml
+++ b/symfony/Resources/config/services.xml
@@ -619,6 +619,9 @@
                 <argument id="import_product_link.observer.product.link" type="service"/>
             </call>
             <call method="addObserver">
+                <argument id="import_product_link.observer.clean.up.product.link" type="service"/>
+            </call>
+            <call method="addObserver">
                 <argument id="import_product_grouped.observer.product.grouped" type="service"/>
             </call>
             <call method="addObserver">


### PR DESCRIPTION
In operation.json you can define Add-Update parameters `'clean-up-links': true,`. The default value is `false`.

To delete a complete link, enter the value `__REMOVE__RELATION__` as SKU in the columns "upsell_skus", "crosssell_skus" or "related_skus".

An empty value ignores the columns.