### PR TITLE
Fix: Fatal error if categories header is not specified

### DIFF
--- a/src/Observers/NormalizeCategoriesObserver.php
+++ b/src/Observers/NormalizeCategoriesObserver.php
@@ -94,6 +94,11 @@ class NormalizeCategoriesObserver extends AbstractProductImportObserver implemen
      */
     protected function process()
     {
+        // do nothing if the categories column is not specified
+        if (!$this->hasHeader(ColumnKeys::CATEGORIES)) {
+            return;
+        }
+
         $this->setValue(ColumnKeys::CATEGORIES, $this->getValue(ColumnKeys::CATEGORIES, null, function ($value) {
             return $this->serializer->normalize($value);
         }));


### PR DESCRIPTION
For delete files we do not need a category. This catches this problem.